### PR TITLE
chore: simplify Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,21 +4,8 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
-    inputs:
-      model:
-        description: "Claude model to use"
-        required: false
-        default: "claude-sonnet-4-5-20250929"
-        type: choice
-        options:
-          - claude-sonnet-4-5-20250929
-          - claude-opus-4-5-20251101
-          - claude-haiku-4-5-20251101
-
 jobs:
   claude-review:
     uses: moment-technology/review-action/.github/workflows/claude-pr-review.yml@v1
-    with:
-      model: ${{ github.event.inputs.model || 'claude-opus-4-5-20251101' }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Remove model selection input from workflow_dispatch trigger
- Remove with.model parameter from the reusable workflow call
- Model selection is now handled centrally by the reusable workflow in review-action

This is part of a bulk update across all repos using the Claude PR review workflow.